### PR TITLE
Add 200 response to the put call in verbs

### DIFF
--- a/Documentation/Verbs.md
+++ b/Documentation/Verbs.md
@@ -96,7 +96,7 @@ The PATCH verb is idempotent in the API, except in some cases, see the "idempote
 May return a 400 when the product is in "read only" mode.
 
 ### PUT
-The PUT verb is used to fully update or replace a resource. It will return a 204 No Content status code on success. In some cases, it may return a 200 OK status code with content.
+On success, it returns a 204 No Content status code. In some cases, it may return 200 OK with a response body — for example, when the PUT route supports an include flag.
 
 The PUT verb is idempotent, except in some cases, see the "idempotence" chapter.
 

--- a/Documentation/Verbs.md
+++ b/Documentation/Verbs.md
@@ -96,7 +96,7 @@ The PATCH verb is idempotent in the API, except in some cases, see the "idempote
 May return a 400 when the product is in "read only" mode.
 
 ### PUT
-The PUT verb is used to fully update or replace a resource. It will return 204 No Content status codes on success.
+The PUT verb is used to fully update or replace a resource. It will return a 204 No Content status code on success. In some cases, it may return a 200 OK status code with content.
 
 The PUT verb is idempotent, except in some cases, see the "idempotence" chapter.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following HTTP status codes can be returned by the services. Check the docum
 
 |Code|Name|Explanation|
 |--|--|--|
-|**200**|OK|Always returned when route did not create resources and a response payload is returned.|
+|**200**|OK|Returned when the request succeeds and a response payload is returned, unless a resource was created (in which case 201 is returned).|
 |**201**|Created|Returned when one or more resources are created.|
 |**202**|Accepted|Asynchronous route is accepted. Used for fire and forget routes.|
 |**204**|No Content|Returned when route did not create resources and no response payload returned.|


### PR DESCRIPTION
Updated the HTTP verbs documentation for PUT requests to clarify that successful responses may return either `204 No Content` or `200 OK`, depending on the endpoint implementation and response content.